### PR TITLE
ignore SSL cert auth when using mlflow logger

### DIFF
--- a/neural_lam/utils.py
+++ b/neural_lam/utils.py
@@ -6,6 +6,7 @@ import warnings
 # Third-party
 import pytorch_lightning as pl
 import torch
+import urllib3
 from pytorch_lightning.loggers import MLFlowLogger, WandbLogger
 from pytorch_lightning.utilities import rank_zero_only
 from torch import nn
@@ -297,6 +298,11 @@ def setup_training_logger(datastore, args, run_name):
             raise ValueError(
                 "MLFlow logger requires setting MLFLOW_TRACKING_URI in env."
             )
+
+        # suppress warnings about insecure requests so that we avoid warnings in
+        # the logs when tracking on the MLflow tracking server
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
         logger = CustomMLFlowLogger(
             experiment_name=args.logger_project,
             tracking_uri=url,


### PR DESCRIPTION
## Describe your changes

Currently our SLURM logs are full of the following kind of warnings during training (which makes using the logs quite hard):

```
 0:   warnings.warn(
 0: ^MEpoch 0:   1% 6/731 [00:14<29:12,  2.42s/it, v_num=d4e6, train_loss_step=nan.0]
 0: ^MEpoch 0:   1% 6/731 [00:14<29:12,  2.42s/it, v_num=d4e6, train_loss_step=nan.0]
 0: /dcai/users/denlef/packages_dvc/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'mlflow.dmi.dcs.dcai.dk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
 0:   warnings.warn(
 0: ^MEpoch 0:   1% 7/731 [00:15<27:19,  2.27s/it, v_num=d4e6, train_loss_step=nan.0]
 0: ^MEpoch 0:   1% 7/731 [00:15<27:20,  2.27s/it, v_num=d4e6, train_loss_step=nan.0]
 0: /dcai/users/denlef/packages_dvc/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'mlflow.dmi.dcs.dcai.dk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
 0:   warnings.warn(
 0: ^MEpoch 0:   1% 8/731 [00:17<25:54,  2.15s/it, v_num=d4e6, train_loss_step=nan.0]^MEpoch 0:   1% 8/731 [00:17<25:54,  2.15s/it, v_num=d4e6, train_loss_step=nan.0]
 0: /dcai/users/denlef/packages_dvc/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'mlflow.dmi.dcs.dcai.dk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
 0:   warnings.warn(
 0: /dcai/users/denlef/packages_dvc/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'mlflow.dmi.dcs.dcai.dk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
 0:   warnings.warn(
 0: /dcai/users/denlef/packages_dvc/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'mlflow.dmi.dcs.dcai.dk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
```

This PR adds a`urllib3` line to ignore warnings about unverified HTTPs connections when using the mlflow logger

no change of deps for this work

## Issue Link

n/a

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [ ] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [ ] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
