### PR TITLE
Add WarmupCosineAnnealing scheduler and allow for specifying number of training steps.

### DIFF
--- a/neural_lam/lr_scheduler.py
+++ b/neural_lam/lr_scheduler.py
@@ -1,8 +1,4 @@
-# Standard library
-import math
-
 # Third-party
-import matplotlib.pyplot as plt
 import torch
 
 
@@ -10,73 +6,43 @@ class WarmupCosineAnnealingLR(torch.optim.lr_scheduler.LRScheduler):
     def __init__(
         self,
         optimizer,
-        total_steps,
-        warmup_steps=1000,
-        max_lr=0.001,
-        min_lr=0.00001,
+        warmup_steps=10,
+        annealing_steps=90,
+        max_factor=1.0,
+        min_factor=0.001,
     ):
-        self.max_steps = max_steps
         self.warmup_steps = warmup_steps
-        self.max_lr = max_lr
-        self.min_lr = min_lr
-        schedule = MattsSchedule(
-            total_steps=100, warmup_steps=55, min_lr=0, max_lr=1
+        self.annealing_steps = annealing_steps
+        initial_learning_rate = optimizer.param_groups[0]["lr"]
+
+        self.warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+            optimizer,
+            start_factor=min_factor,
+            end_factor=max_factor,
+            total_iters=warmup_steps,
         )
+
+        self.annealing_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer,
+            T_max=annealing_steps,
+            eta_min=min_factor * initial_learning_rate,
+        )
+
         super().__init__(optimizer)
 
     def get_lr(self):
-        self.base_lrs
-        lrs = [1 for group in self.optimizer.param_groups]
-        return lrs
+        if self.last_epoch <= self.warmup_steps:
+            return self.warmup_scheduler.get_last_lr()
+        elif self.last_epoch <= self.warmup_steps + self.annealing_steps:
+            self.annealing_scheduler.step()
 
-    def warmup(self, step):
-        return step / self.warmup_steps * self.max
+        return True
 
-    def cosine_annealing(self, step):
-        if step > self.max_steps:
-            return self.min
-
-        return self.min + 0.5 * (self.max_lr - self.min_lr) * (
-            1 + math.cos(math.pi * step / self.max_steps)
-        )
-
-
-class MattsSchedule:
-    def __init__(
-        self,
-        total_steps,
-        warmup_steps=1000,
-        min_lr=0.00001,
-        max_lr=0.001,
-    ):
-        self.max_steps = total_steps
-        self.warmup_steps = warmup_steps
-        self.annealing_steps = total_steps - warmup_steps
-
-        self.max_lr = max_lr
-        self.min_lr = min_lr
-
-    def warmup(self, step):
-        return step / self.warmup_steps * self.max_lr
-
-    def cosine_annealing(self, step):
-        return self.min_lr + 0.5 * (self.max_lr - self.min_lr) * (
-            1 + math.cos(math.pi * step / self.annealing_steps)
-        )
-
-    def calculate_lr(self, step):
-        if step < self.warmup_steps:
-            lr = self.warmup(step)
-        elif step < self.max_steps:
-            lr = self.cosine_annealing(step - self.warmup_steps)
-        else:
-            lr = self.min_lr
-        return lr
-
-    def get_lr(self, step):
-        __import__("pdb").set_trace()  # TODO delme kj:w
-
-        return [self.calculate_lr(step) for _ in optimizer.param_groups]
-
-    def __len__(self):
-        return self.max_steps
+    def step(self):
+        if self._step_count == 0:
+            pass
+        elif self._step_count <= self.warmup_steps:
+            self.warmup_scheduler.step()
+        elif self._step_count <= self.warmup_steps + self.annealing_steps:
+            self.annealing_scheduler.step()
+        self._step_count += 1

--- a/neural_lam/lr_scheduler.py
+++ b/neural_lam/lr_scheduler.py
@@ -46,3 +46,34 @@ class WarmupCosineAnnealingLR(torch.optim.lr_scheduler.LRScheduler):
         elif self._step_count <= self.warmup_steps + self.annealing_steps:
             self.annealing_scheduler.step()
         self._step_count += 1
+
+
+if __name__ == "__main__":
+    # Third-party
+    import matplotlib.pyplot as plt
+
+    model = torch.nn.Linear(1, 1)
+    opt = torch.optim.Adam(model.parameters())
+    scheduler = WarmupCosineAnnealingLR(
+        opt, warmup_steps=20, annealing_steps=100
+    )
+
+    lrs = []
+    for _ in range(150):
+        lrs.append(opt.param_groups[0]["lr"])
+        scheduler.step()
+
+    plt.plot(lrs)
+    plt.vlines(20, 0, max(lrs), colors="k", linestyles="dashed")
+    plt.vlines(120, 0, max(lrs), colors="k", linestyles="dashed")
+    plt.text(21, max(lrs) / 2, "warmup ended", fontsize=10, color="k")
+    plt.text(121, max(lrs) / 2, "annealing ended", fontsize=10, color="k")
+
+    plt.hlines(max(lrs), 15, 25, colors="k", linestyles="dashed")
+    plt.text(26, max(lrs), f"{max(lrs):.2e}", fontsize=10, color="k")
+    plt.text(121, min(lrs), f"{min(lrs):.2e}", fontsize=10, color="k")
+
+    plt.xlabel("Step")
+    plt.ylabel("Learning Rate")
+
+    plt.show()

--- a/neural_lam/lr_scheduler.py
+++ b/neural_lam/lr_scheduler.py
@@ -1,0 +1,82 @@
+# Standard library
+import math
+
+# Third-party
+import matplotlib.pyplot as plt
+import torch
+
+
+class WarmupCosineAnnealingLR(torch.optim.lr_scheduler.LRScheduler):
+    def __init__(
+        self,
+        optimizer,
+        total_steps,
+        warmup_steps=1000,
+        max_lr=0.001,
+        min_lr=0.00001,
+    ):
+        self.max_steps = max_steps
+        self.warmup_steps = warmup_steps
+        self.max_lr = max_lr
+        self.min_lr = min_lr
+        schedule = MattsSchedule(
+            total_steps=100, warmup_steps=55, min_lr=0, max_lr=1
+        )
+        super().__init__(optimizer)
+
+    def get_lr(self):
+        self.base_lrs
+        lrs = [1 for group in self.optimizer.param_groups]
+        return lrs
+
+    def warmup(self, step):
+        return step / self.warmup_steps * self.max
+
+    def cosine_annealing(self, step):
+        if step > self.max_steps:
+            return self.min
+
+        return self.min + 0.5 * (self.max_lr - self.min_lr) * (
+            1 + math.cos(math.pi * step / self.max_steps)
+        )
+
+
+class MattsSchedule:
+    def __init__(
+        self,
+        total_steps,
+        warmup_steps=1000,
+        min_lr=0.00001,
+        max_lr=0.001,
+    ):
+        self.max_steps = total_steps
+        self.warmup_steps = warmup_steps
+        self.annealing_steps = total_steps - warmup_steps
+
+        self.max_lr = max_lr
+        self.min_lr = min_lr
+
+    def warmup(self, step):
+        return step / self.warmup_steps * self.max_lr
+
+    def cosine_annealing(self, step):
+        return self.min_lr + 0.5 * (self.max_lr - self.min_lr) * (
+            1 + math.cos(math.pi * step / self.annealing_steps)
+        )
+
+    def calculate_lr(self, step):
+        if step < self.warmup_steps:
+            lr = self.warmup(step)
+        elif step < self.max_steps:
+            lr = self.cosine_annealing(step - self.warmup_steps)
+        else:
+            lr = self.min_lr
+        return lr
+
+    def get_lr(self, step):
+        __import__("pdb").set_trace()  # TODO delme kj:w
+
+        return [self.calculate_lr(step) for _ in optimizer.param_groups]
+
+    def __len__(self):
+        return self.max_steps

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -193,6 +193,7 @@ class ARModel(pl.LightningModule):
         opt = torch.optim.AdamW(
             self.parameters(), lr=self.args.lr, betas=(0.9, 0.95)
         )
+
         return opt
 
     @property

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -73,6 +73,12 @@ def main(input_args=None):
         help="upper epoch limit (default: 200)",
     )
     parser.add_argument(
+        "--steps",
+        type=int,
+        default=-1,
+        help="upper step limit (default: None)",
+    )
+    parser.add_argument(
         "--batch_size", type=int, default=4, help="batch size (default: 4)"
     )
     parser.add_argument(
@@ -308,6 +314,7 @@ def main(input_args=None):
     )
     trainer = pl.Trainer(
         max_epochs=args.epochs,
+        max_steps=args.steps,
         deterministic=True,
         strategy="ddp",
         accelerator=device_name,

--- a/tests/test_lr_scheduler.py
+++ b/tests/test_lr_scheduler.py
@@ -1,8 +1,6 @@
-# Standard library
-import warnings
-from unittest.mock import MagicMock
-
 # Third-party
+import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 import torch
 
@@ -17,9 +15,43 @@ def model():
 
 @pytest.fixture
 def optimizer(model):
-    return torch.optim.SGD(model.parameters(), lr=0.01)  # Real optimizer
+    return torch.optim.Adam(model.parameters())  # Real optimizer
 
 
 def test_warmup_cosine_annealing_can_instantiate(optimizer):
-    lrs = lr_scheduler.WarmupCosineAnnealingLR(optimizer, max_steps=1000)
-    __import__("pdb").set_trace()  # TODO delme
+    min_factor = 0.001
+    max_factor = 1
+    warmup_steps = 10
+    annealing_steps = 10
+    initial_lr = optimizer.param_groups[0]["lr"]
+
+    linear = lr_scheduler.WarmupCosineAnnealingLR(
+        optimizer,
+        min_factor=min_factor,
+        max_factor=max_factor,
+        annealing_steps=annealing_steps,
+        warmup_steps=warmup_steps,
+    )
+
+    lrs = []
+    for _ in range(25):
+        lrs.append(optimizer.param_groups[0]["lr"])
+        linear.step()
+
+    expected_warmup_lr = np.linspace(
+        min_factor * initial_lr,
+        max_factor * initial_lr,
+        warmup_steps,
+        endpoint=False,
+    )
+    warmup_lr = lrs[:warmup_steps]
+    assert np.allclose(warmup_lr, expected_warmup_lr)
+
+    annealing_lr = lrs[warmup_steps : warmup_steps + annealing_steps]
+    expected_annealing_lr = min_factor * initial_lr + 0.5 * (
+        max_factor * initial_lr - min_factor * initial_lr
+    ) * (1 + np.cos(np.pi * np.arange(annealing_steps) / annealing_steps))
+    assert np.allclose(annealing_lr, expected_annealing_lr)
+
+    last_lr = lrs[-1]
+    assert all(lrs[-5:] == np.ones(5) * last_lr)

--- a/tests/test_lr_scheduler.py
+++ b/tests/test_lr_scheduler.py
@@ -1,0 +1,25 @@
+# Standard library
+import warnings
+from unittest.mock import MagicMock
+
+# Third-party
+import pytest
+import torch
+
+# First-party
+from neural_lam import lr_scheduler
+
+
+@pytest.fixture
+def model():
+    return torch.nn.Linear(1, 1)
+
+
+@pytest.fixture
+def optimizer(model):
+    return torch.optim.SGD(model.parameters(), lr=0.01)  # Real optimizer
+
+
+def test_warmup_cosine_annealing_can_instantiate(optimizer):
+    lrs = lr_scheduler.WarmupCosineAnnealingLR(optimizer, max_steps=1000)
+    __import__("pdb").set_trace()  # TODO delme

--- a/tests/test_lr_scheduler.py
+++ b/tests/test_lr_scheduler.py
@@ -19,13 +19,13 @@ def optimizer(model):
 
 
 def test_warmup_cosine_annealing_can_instantiate(optimizer):
-    min_factor = 0.001
+    min_factor = 0.01
     max_factor = 1
     warmup_steps = 10
     annealing_steps = 10
     initial_lr = optimizer.param_groups[0]["lr"]
 
-    linear = lr_scheduler.WarmupCosineAnnealingLR(
+    scheduler = lr_scheduler.WarmupCosineAnnealingLR(
         optimizer,
         min_factor=min_factor,
         max_factor=max_factor,
@@ -36,7 +36,7 @@ def test_warmup_cosine_annealing_can_instantiate(optimizer):
     lrs = []
     for _ in range(25):
         lrs.append(optimizer.param_groups[0]["lr"])
-        linear.step()
+        scheduler.step()
 
     expected_warmup_lr = np.linspace(
         min_factor * initial_lr,


### PR DESCRIPTION
This PR implements 2 features. 

1) A `--steps` argument has been added to the training script, allowing control over the number of training steps before termination. This is implemented using `Trainer(..., max_num_steps=args.steps, ...)` in pytorch_lightning. If both `max_num_epochs` and `max_num_steps` are specified in the `Trainer`, training will stop when either has been reached. By default `"--steps"` is -1 which means that without specifying this keyword, training will never terminate due to `max_num_steps`. 

2) A learning scheduler to NeuralLAM following the specifications given by Matt Chantry at the developer meeting at DMI 4th of March. The defaults are implemented such that when using the default learning rate for Adam (`1e-3`) the linear warmup will range from epsilon to `1e-3` and then cosine annealing from 1e-3 to 1e-6. Otherwise, min and max learning rate will range from `min_factor * initial_lr` to `max_factor * initial_lr)`
The signature and defaults of the scheduler is

```
neural_lam.lr_scheduler.WarmupCosineAnnealingLR(
        optimizer,
        warmup_steps=100000,
        annealing_steps=1000,
        max_factor=1.0,
        min_factor=0.001,
)
```

The scheduler has 3 phases:

## Warmup phase
In this phase the learning rate is warmed up by linearly increasing the learning rate from `min_factor * initial_learning_rate` to `max_factor * initial_learning_rate` (The learning rate is defined in the optimizer).

## Annealing phase
In this phase the learning rate is annealed by using a CosineAnnealing schedule that anneals the learning rate back to `min_factor * initial_learning_rate` by following a half a cosing cycle. 

## Fine tuning phase
In this phase the annealed learning rate is used until the training terminates.

# Learning schedule
Using the default learning rate for the adam optimizer (1e-3), 20 warmup steps, 100 annealing steps and 150 steps in total will produce a schedule that looks as folllows: 

```
WarmupCosineAnnealingLR(
        optimizer,
        warmup_steps=20,
        annealing_steps=100,
)
```

![image](https://github.com/user-attachments/assets/2e934f9f-77e1-40c8-a608-cd73e5aaaddd)

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [x] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee.

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed* or *fixed*)
- Once the PR is ready to be merged, squash commits and merge the PR.
